### PR TITLE
use static linking for openssl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           export VERSION=$(echo ${{ github.ref }} | sed -e 's/[^0-9\.]//g')
           sed -i '' 's/version = "0.1.0"/version = "'${VERSION}'"/' Cargo.toml
+          export OPENSSL_STATIC=1
           cargo build --release
           echo ::set-output name=VERSION::${VERSION}
       - name: Archive


### PR DESCRIPTION
The build that is attached to the release is generated by a GitHub Action, but I only just noticed it is dynamically linked to OpenSSL. But that is something you usually have to install yourself via something like homebrew, not available on every MacOS installation. This change _should_ make it statically linked, meaning it should actually work without having to install libopenssl locally.